### PR TITLE
利用規約をログインなしで閲覧可能にした

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,3 +1,5 @@
 class PagesController < ApplicationController
+  skip_before_action :authenticate_user!, only: [:terms]
+
   def terms; end
 end


### PR DESCRIPTION
- [x] pages_controllerにskip_before_action :authenticate_user!, only: [:terms]を追加した
